### PR TITLE
Add what_git_branch/get_environment and what_git_branch/production_environment filters

### DIFF
--- a/what-git-branch.php
+++ b/what-git-branch.php
@@ -624,8 +624,14 @@ class CSSLLC_What_Git_Branch {
 }
 
 add_action( 'init', static function() : void {
+	$environment = apply_filters(
+		'what_git_branch/get_environment',
+		function_exists( 'wp_get_environment_type' ) && defined( 'WP_ENVIRONMENT_TYPE' ) ? wp_get_environment_type() : 'local'
+	);
+	$production  = apply_filters( 'what_git_branch/production_environment', 'production' );
+
 	if (
-		'production' === wp_get_environment_type()
+		$production === $environment
 		|| ! current_user_can( 'manage_options' )
 	) {
 		return;


### PR DESCRIPTION
Add WP filters to control production environment name as well as filters that manage how the current environment name is retrieved.

This also adds support for WP sites older than 5.5 that can't support `wp_get_environment_type()`. For example, Bamco is on 5.3.12 and only updates when security updates are released.